### PR TITLE
MERGE: have phylotyper retrieve seq directly from graphs

### DIFF
--- a/app/middleware/blazegraph/reserve_id.py
+++ b/app/middleware/blazegraph/reserve_id.py
@@ -168,8 +168,10 @@ def reserve_id(query_file):
     spfyid, duplicate = _check(uriGenome)
 
     # Create a rdflib.graph object with the spfyID.
+    # We create this outside of the duplicate check because phylotyper
+    # requires it regardless.
     graph = Graph()
-    graph = reservation_triple(graph, uriGenome, largest+1)
+    graph = reservation_triple(graph, uriGenome, spfyid)
 
     if not duplicate:
         # Uploading the reservation graph secures the file->spfyID link

--- a/app/middleware/graphers/datastruct_savvy.py
+++ b/app/middleware/graphers/datastruct_savvy.py
@@ -231,4 +231,5 @@ def datastruct_savvy(query_file, id_file, pickled_dictionary):
     :return:
     """
     graph = generate_datastruct(query_file, id_file, pickled_dictionary)
-    return queue_upload(graph)
+    queue_upload(graph)
+    return graph

--- a/app/middleware/graphers/turtle_grapher.py
+++ b/app/middleware/graphers/turtle_grapher.py
@@ -115,4 +115,5 @@ def generate_turtle_skeleton(query_file):
 
 def turtle_grapher(query_file):
     graph = generate_turtle_skeleton(query_file)
-    return queue_upload(graph)
+    queue_upload(graph)
+    return graph

--- a/app/modules/pan_spfy.py
+++ b/app/modules/pan_spfy.py
@@ -16,7 +16,7 @@ from rq import Queue
 from rdflib import Graph
 
 from modules.qc.qc import qc
-from middleware.blazegraph.reserve_id import write_reserve_id
+from middleware.blazegraph.reserve_id import reserve_id
 from modules.amr.amr import amr
 from modules.amr.amr_to_dict import amr_to_dict
 from middleware.display.beautify import beautify
@@ -111,7 +111,7 @@ def blob_savvy_enqueue(single_dict):
         query_file = single_dict['i'][0]
         for file in query_list:
             job_qc = multiples_q.enqueue(qc, file, result_ttl=-1)
-            job_id = blazegraph_q.enqueue(write_reserve_id, file, depends_on=job_qc, result_ttl=-1)
+            job_id = blazegraph_q.enqueue(reserve_id, file, depends_on=job_qc, result_ttl=-1)
             pan_jobs[job_qc.get_id()] = {'file': file, 'analysis': 'Quality Control'}
             pan_jobs[job_id.get_id()] = {'file': file, 'analysis': 'ID Reservation'}
 

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -18,6 +18,7 @@ import pandas as pd
 import cPickle as pickle
 from rdflib import Graph, BNode, Literal, XSD
 import re
+import redis
 from collections import OrderedDict
 from redis import Redis
 

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -34,7 +34,7 @@ def _check_tsv(pt_file):
     if pt_results.empty:
         raise Exception('_check_tsv() failed as pt_results.empty == true for pt_file: {0} with df content: {1}'.format(pt_file, str(pt_results)))
 
-def phylotyper(uriIsolate, subtype, result_file, id_file=None, query_file=None):
+def phylotyper(uriIsolate, subtype, result_file, id_file=None, job_id=None, job_turtle=None, job_ectyper_datastruct_vf=None):
     """ Wrapper for Phylotyper
 
     Args:
@@ -72,18 +72,17 @@ def phylotyper(uriIsolate, subtype, result_file, id_file=None, query_file=None):
     loci = [ gu(l['locus']) for l in sorted(loci_results, key=lambda k: k['i'])]
 
     # Get alleles for this genome
-    # markerseqs = MarkerSequences(loci)
-    # fasta = markerseqs.fasta(uriIsolate)
-    # fasta =
+    markerseqs = MarkerSequences(loci, job_id, job_turtle, job_ectyper_datastruct_vf)
+    fasta = markerseqs.fasta(uriIsolate)
 
     temp_dir = mkdtemp(prefix='pt'+subtype, dir=config.DATASTORE)
-    # query_file = os.path.join(temp_dir, 'query.fasta')
+    query_file = os.path.join(temp_dir, 'query.fasta')
     output_file = os.path.join(temp_dir, 'subtype_predictions.tsv')
 
     if query_file:
         # Run phylotyper
-        # with open(query_file, 'w') as fh:
-        #     fh.write(fasta)
+        with open(query_file, 'w') as fh:
+            fh.write(fasta)
 
         subprocess.check_call(['phylotyper', 'genome', '--noplots',
                          subtype,

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -244,7 +244,7 @@ def savvy(p_file, subtype):
     # Load data
     pt_dict = pickle.load(open(p_file, 'rb'))
 
-    if pt_dict['subtype'] != 'No loci':
+    if 'No loci' not in pt_dict['subtype']:
 
         # Phylotyper scheme
         phylotyper_uri = gu('subt:'+subtype)

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -135,7 +135,7 @@ def to_dict(pt_file, subtype, pickle_file):
         #     str(pt_results)
         # ))
         pt_results = {
-            'subtype': 'No loci',
+            'subtype': '{0}: No loci'.format(subtype),
         }
 
     else:

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -186,11 +186,11 @@ def beautify(p_file, genome):
 
     #print(pt_dict)
 
-    if pt_dict['subtype'] == 'No loci':
+    if 'No loci' in pt_dict['subtype']:
         table_rows = [
             {
                 'genome': genome,
-                'subtype_gene': 'N/A',
+                'subtype_gene': pt_dict['subtype'].split(':')[0],
                 'start': 'N/A',
                 'stop': 'N/A',
                 'contig': 'N/A',
@@ -341,7 +341,7 @@ def ignorant(genome_uri, subtype, pickle_file):
     if not results:
         # raise Exception("ignorant() could not find phylotyper results for genome_uri: {0}, subtype: {1}, with pickle_file: {2}".format(genome_uri, subtype, pickle_file))
         pt_dict = {
-            'subtype': 'No loci'
+            'subtype': '{0}: No loci'.format(subtype)
         }
 
     pickle.dump(pt_dict, open(pickle_file, 'wb'))

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -19,6 +19,7 @@ import cPickle as pickle
 from rdflib import Graph, BNode, Literal, XSD
 import re
 from collections import OrderedDict
+from redis import Redis
 
 
 import config
@@ -28,6 +29,9 @@ from modules.phylotyper import ontology, exceptions
 from modules.phylotyper.sequences import MarkerSequences, phylotyper_query, genename_query
 
 logger = logging.getLogger(__name__)
+
+redis_url = config.REDIS_URL
+redis_conn = redis.from_url(redis_url)
 
 def _check_tsv(pt_file):
     pt_results = pd.read_table(pt_file)
@@ -72,7 +76,7 @@ def phylotyper(uriIsolate, subtype, result_file, id_file=None, job_id=None, job_
     loci = [ gu(l['locus']) for l in sorted(loci_results, key=lambda k: k['i'])]
 
     # Get alleles for this genome
-    markerseqs = MarkerSequences(loci, job_id, job_turtle, job_ectyper_datastruct_vf)
+    markerseqs = MarkerSequences(loci, job_id, job_turtle, job_ectyper_datastruct_vf, redis_conn)
     fasta = markerseqs.fasta(uriIsolate)
 
     temp_dir = mkdtemp(prefix='pt'+subtype, dir=config.DATASTORE)

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -34,7 +34,7 @@ def _check_tsv(pt_file):
     if pt_results.empty:
         raise Exception('_check_tsv() failed as pt_results.empty == true for pt_file: {0} with df content: {1}'.format(pt_file, str(pt_results)))
 
-def phylotyper(uriIsolate, subtype, result_file, id_file=None):
+def phylotyper(uriIsolate, subtype, result_file, id_file=None, query_file=None):
     """ Wrapper for Phylotyper
 
     Args:
@@ -42,6 +42,7 @@ def phylotyper(uriIsolate, subtype, result_file, id_file=None):
         subtype (str): Phylotyper recognized subtype (e.g. stx1)
         result_file (str): File location to write phylotyper tab-delim result to
         id_file (str)[OPTIONAL]: Read uriIsolate from file
+        query_file (str): Overides VF lookup and runs on the genome directly.
 
     Returns:
         file to tab-delimited text results
@@ -71,18 +72,18 @@ def phylotyper(uriIsolate, subtype, result_file, id_file=None):
     loci = [ gu(l['locus']) for l in sorted(loci_results, key=lambda k: k['i'])]
 
     # Get alleles for this genome
-    markerseqs = MarkerSequences(loci)
-    fasta = markerseqs.fasta(uriIsolate)
+    # markerseqs = MarkerSequences(loci)
+    # fasta = markerseqs.fasta(uriIsolate)
     # fasta =
 
     temp_dir = mkdtemp(prefix='pt'+subtype, dir=config.DATASTORE)
-    query_file = os.path.join(temp_dir, 'query.fasta')
+    # query_file = os.path.join(temp_dir, 'query.fasta')
     output_file = os.path.join(temp_dir, 'subtype_predictions.tsv')
 
-    if fasta:
+    if query_file:
         # Run phylotyper
-        with open(query_file, 'w') as fh:
-            fh.write(fasta)
+        # with open(query_file, 'w') as fh:
+        #     fh.write(fasta)
 
         subprocess.check_call(['phylotyper', 'genome', '--noplots',
                          subtype,

--- a/app/modules/phylotyper/phylotyper.py
+++ b/app/modules/phylotyper/phylotyper.py
@@ -48,6 +48,9 @@ def phylotyper(uriIsolate, subtype, result_file, id_file=None, job_id=None, job_
         result_file (str): File location to write phylotyper tab-delim result to
         id_file (str)[OPTIONAL]: Read uriIsolate from file
         query_file (str): Overides VF lookup and runs on the genome directly.
+        job_id (str): the rq.job.Job.get_id() for the SpfyID job.
+        job_turtle (str)
+        job_ectyper_datastruct_vf (str)
 
     Returns:
         file to tab-delimited text results

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -119,7 +119,7 @@ class MarkerSequences(object):
         # convert to proper RDF terms
         self.marker_uris = [turtle_utils.normalize_rdfterm(m) for m in markers]
         # Retrieve and merge graphs from pre-req. jobs.
-        self.graph = fetch_job(job_id, redis_conn) + fetch_job(job_turtle, redis_conn) + fetch_job(job_ectyper_datastruct_vf, redis_conn)
+        self.graph = fetch_job(job_id, redis_conn).result + fetch_job(job_turtle, redis_conn).result + fetch_job(job_ectyper_datastruct_vf, redis_conn).result
 
 
     def sequences(self, genome_uri):

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -166,7 +166,6 @@ class MarkerSequences(object):
             }
             for tup in query_result
         ]
-        raise Exception('sequences() query_result: {0}'.format(l))
 
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -24,8 +24,6 @@ def marker_query(marker_uris):
 
   return query
 
-@tojson
-@submit
 @prefix
 def sequence_query(marker_rdf, isolate_rdf):
 
@@ -136,7 +134,10 @@ class MarkerSequences(object):
         """
 
         genome_rdf = turtle_utils.normalize_rdfterm(genome_uri)
-        query_result = sequence_query(self.marker_uris, genome_rdf)
+        query = sequence_query(self.marker_uris, genome_rdf)
+        # query_result = sequence_query(self.marker_uris, genome_rdf)
+        query_result self.graph.query(query)
+        print(query_result)
 
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -54,11 +54,12 @@ def sequence_query(marker_rdf, isolate_rdf):
     #     '''.format(isolate_rdf, ' '.join(marker_rdf))
 
     query = '''
-        SELECT ?g
+        SELECT *
         WHERE {{
             ?g a :spfyId .
+            VALUES ?g {{ {} }}
         }}
-    '''
+    '''.format(isolate_rdf)
 
     return query
 

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -139,7 +139,7 @@ class MarkerSequences(object):
             dictionary
 
         """
-        raise Exception('graph: {0}'.format(self.graph.serialize(format="turtle")))
+        #raise Exception('graph: {0}'.format(self.graph.serialize(format="turtle")))
         genome_rdf = turtle_utils.normalize_rdfterm(genome_uri)
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -170,7 +170,7 @@ class MarkerSequences(object):
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(
             turtle_utils.fulluri_to_basename(r['region']),
-            r['contigid'], r['start'], r['start']+r['len']-1): r['seq'] for r in query_result }
+            r['contigid'], r['start'], r['start']+r['len']-1): r['seq'] for r in l }
 
         return seqdict
 

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -137,6 +137,7 @@ class MarkerSequences(object):
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)
         query_result = self.graph.query(query)
+        query_result = [row for row in query_result]
         raise Exception('sequences() query_result: {0}'.format(query_result))
 
         # Unroll result into dictionary with fasta-like keys

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -137,7 +137,7 @@ class MarkerSequences(object):
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)
         query_result = self.graph.query(query)
-        print('sequences() query_result: {0}'.format(query_result))
+        raise Exception('sequences() query_result: {0}'.format(query_result))
 
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -153,18 +153,6 @@ class MarkerSequences(object):
         # Retrieve and merge graphs from pre-req. jobs.
         self.graph = g + fetch_job(job_id, redis_conn).result + fetch_job(job_turtle, redis_conn).result + fetch_job(job_ectyper_datastruct_vf, redis_conn).result
 
-
-    def _unroll(self, query_result):
-        '''
-        Custom method to convert query results into the same dictionary format as decorators.to_json().
-        :param query_result: 
-        :return: 
-        '''
-        l = []
-        for tup in query_result:
-
-
-
     def sequences(self, genome_uri):
         """Retrieve sequences for object alleles
 

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -154,6 +154,17 @@ class MarkerSequences(object):
         self.graph = g + fetch_job(job_id, redis_conn).result + fetch_job(job_turtle, redis_conn).result + fetch_job(job_ectyper_datastruct_vf, redis_conn).result
 
 
+    def _unroll(self, query_result):
+        '''
+        Custom method to convert query results into the same dictionary format as decorators.to_json().
+        :param query_result: 
+        :return: 
+        '''
+        l = []
+        for tup in query_result:
+
+
+
     def sequences(self, genome_uri):
         """Retrieve sequences for object alleles
 
@@ -170,7 +181,19 @@ class MarkerSequences(object):
         # query_result = sequence_query(self.marker_uris, genome_rdf)
         query_result = self.graph.query(query)
         query_result = [row for row in query_result]
-        raise Exception('sequences() query_result: {0}'.format(query_result))
+        # ?contig ?contigid ?region ?start ?len ?seq
+        l = [
+            {
+                'contig': tup[0].toPython(),
+                'contigid': tup[1].toPython(),
+                'region': tup[2].toPython(),
+                'start': tup[3].toPython(),
+                'len': tup[4].toPython(),
+                'seq': tup[5].toPython()
+            }
+            for tup in query_result
+        ]
+        raise Exception('sequences() query_result: {0}'.format(l))
 
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -132,7 +132,7 @@ class MarkerSequences(object):
             dictionary
 
         """
-
+        raise Exception('graph: {0}'.format(self.graph.serialize(format="turtle")))
         genome_rdf = turtle_utils.normalize_rdfterm(genome_uri)
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -168,16 +168,15 @@ class MarkerSequences(object):
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)
         query_result = self.graph.query(query)
-        query_result = [row for row in query_result]
         # ?contig ?contigid ?region ?start ?len ?seq
         l = [
             {
-                'contig': tup[0].toPython(),
-                'contigid': tup[1].toPython(),
-                'region': tup[2].toPython(),
-                'start': tup[3].toPython(),
-                'len': tup[4].toPython(),
-                'seq': tup[5].toPython()
+                'contig': str(tup[0].toPython()),
+                'contigid': str(tup[1].toPython()),
+                'region': str(tup[2].toPython()),
+                'start': int(tup[3].toPython().strip('L')),
+                'len': int(tup[4].toPython().strip('L')),
+                'seq': str(tup[5].toPython())
             }
             for tup in query_result
         ]

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -58,6 +58,8 @@ def sequence_query(marker_rdf, isolate_rdf):
         WHERE {{
             ?g a :spfyId .
             VALUES ?g {{ {} }}
+            ?contig a g:Contig ;
+    #           g:Identifier ?contigid .
         }}
     '''.format(isolate_rdf)
 

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -5,10 +5,13 @@ Example:
     $ python sequences.py -s stx1
 
 """
-
+import os
+from rdflib import Graph
 from middleware.decorators import submit, prefix, tojson
 from middleware.graphers import turtle_utils
 from routes.job_utils import fetch_job
+
+__location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
 @submit
 @prefix
@@ -118,8 +121,12 @@ class MarkerSequences(object):
 
         # convert to proper RDF terms
         self.marker_uris = [turtle_utils.normalize_rdfterm(m) for m in markers]
+        # Read the phylotyper ontology as a starter graph.
+        g = Graph()
+        ontology_turtle_file = os.path.join(__location__, 'superphy_subtyping.ttl')
+        g.parse(ontology_turtle_file, format="turtle")
         # Retrieve and merge graphs from pre-req. jobs.
-        self.graph = fetch_job(job_id, redis_conn).result + fetch_job(job_turtle, redis_conn).result + fetch_job(job_ectyper_datastruct_vf, redis_conn).result
+        self.graph = g + fetch_job(job_id, redis_conn).result + fetch_job(job_turtle, redis_conn).result + fetch_job(job_ectyper_datastruct_vf, redis_conn).result
 
 
     def sequences(self, genome_uri):

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -13,20 +13,6 @@ from routes.job_utils import fetch_job
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-@submit
-@prefix
-def marker_query(marker_uris):
-
-  query = '''
-  SELECT ?m
-  WHERE {{
-    ?m rdf:type :Marker .
-    VALUES ?m {{ {} }}
-  }}
-  '''.format(' '.join(marker_uris))
-
-  return query
-
 @prefix
 def sequence_query(marker_rdf, isolate_rdf):
     # query = '''
@@ -174,8 +160,8 @@ class MarkerSequences(object):
                 'contig': str(tup[0].toPython()),
                 'contigid': str(tup[1].toPython()),
                 'region': str(tup[2].toPython()),
-                'start': int(tup[3].toPython().strip('L')),
-                'len': int(tup[4].toPython().strip('L')),
+                'start': int(tup[3].toPython()),
+                'len': int(tup[4].toPython()),
                 'seq': str(tup[5].toPython())
             }
             for tup in query_result

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -29,30 +29,36 @@ def marker_query(marker_uris):
 
 @prefix
 def sequence_query(marker_rdf, isolate_rdf):
+    # query = '''
+    #         SELECT ?contig ?contigid ?region ?start ?len ?seq
+    #         WHERE {{
+    #             ?g a :spfyId .
+    #             VALUES ?g {{ {} }}
+    #             ?contig a g:Contig ;
+    #                 g:Identifier ?contigid .
+    #             ?m a :VirulenceFactor .
+    #             ?contig g:DNASequence ?dna .
+    #             VALUES ?m {{ {} }} .
+    #             ?region a faldo:Region ;
+    #                 :hasPart ?m ;
+    #                 :isFoundIn ?contig ;
+    #                 :isFoundIn ?g ;
+    #                 faldo:begin ?b ;
+    #                 faldo:end ?e .
+    #             ?b faldo:position ?beginPos .
+    #             ?e faldo:position ?endPos .
+    #             BIND( IF(?beginPos < ?endPos,?beginPos,?endPos) as ?start)
+    #             BIND( IF(?beginPos < ?endPos,?endPos-?beginPos+1,?beginPos-?endPos+1) as ?len)
+    #             BIND( SUBSTR( ?dna, ?start, ?len ) as ?seq )
+    #         }}
+    #     '''.format(isolate_rdf, ' '.join(marker_rdf))
 
     query = '''
-        SELECT ?contig ?contigid ?region ?start ?len ?seq
+        SELECT ?g
         WHERE {{
             ?g a :spfyId .
-            VALUES ?g {{ {} }}
-            ?contig a g:Contig ;
-                g:Identifier ?contigid .
-            ?m a :VirulenceFactor .
-            ?contig g:DNASequence ?dna .
-            VALUES ?m {{ {} }} .
-            ?region a faldo:Region ;
-                :hasPart ?m ;
-                :isFoundIn ?contig ;
-                :isFoundIn ?g ;
-                faldo:begin ?b ;
-                faldo:end ?e .
-            ?b faldo:position ?beginPos .
-            ?e faldo:position ?endPos .
-            BIND( IF(?beginPos < ?endPos,?beginPos,?endPos) as ?start)
-            BIND( IF(?beginPos < ?endPos,?endPos-?beginPos+1,?beginPos-?endPos+1) as ?len)
-            BIND( SUBSTR( ?dna, ?start, ?len ) as ?seq )
         }}
-    '''.format(isolate_rdf, ' '.join(marker_rdf))
+    '''
 
     return query
 

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -108,7 +108,7 @@ class MarkerSequences(object):
 
     """
 
-    def __init__(self, markers=[':stx2A',':stx2B'], job_id, job_turtle, job_ectyper_datastruct_vf, redis_conn):
+    def __init__(self, markers=[':stx2A',':stx2B'], job_id=None, job_turtle=None, job_ectyper_datastruct_vf=None, redis_conn=None):
         """Constructor
 
         Args:
@@ -119,7 +119,7 @@ class MarkerSequences(object):
         # convert to proper RDF terms
         self.marker_uris = [turtle_utils.normalize_rdfterm(m) for m in markers]
         # Retrieve and merge graphs from pre-req. jobs.
-        self.graph = fetch_job(job_id, redis_conn) + fetch_job(job_turtle redis_conn) + fetch_job(job_ectyper_datastruct_vf, redis_conn)
+        self.graph = fetch_job(job_id, redis_conn) + fetch_job(job_turtle, redis_conn) + fetch_job(job_ectyper_datastruct_vf, redis_conn)
 
 
     def sequences(self, genome_uri):
@@ -136,7 +136,7 @@ class MarkerSequences(object):
         genome_rdf = turtle_utils.normalize_rdfterm(genome_uri)
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)
-        query_result self.graph.query(query)
+        query_result = self.graph.query(query)
         print(query_result)
 
         # Unroll result into dictionary with fasta-like keys

--- a/app/modules/phylotyper/sequences.py
+++ b/app/modules/phylotyper/sequences.py
@@ -137,7 +137,7 @@ class MarkerSequences(object):
         query = sequence_query(self.marker_uris, genome_rdf)
         # query_result = sequence_query(self.marker_uris, genome_rdf)
         query_result = self.graph.query(query)
-        print(query_result)
+        print('sequences() query_result: {0}'.format(query_result))
 
         # Unroll result into dictionary with fasta-like keys
         seqdict = { "spfy|{}| {}:{}..{}".format(

--- a/app/modules/spfy.py
+++ b/app/modules/spfy.py
@@ -331,6 +331,7 @@ def _phylotyper_pipeline(subtype, query_file, pipeline=None, backlog=False):
         subtype,
         tsvfile,
         id_file=query_file + '_id.txt',
+        query_file=query_file,
         depends_on=job_ectyper_datastruct_vf)
     pipeline.jobs.update({
         'job'+jobname: Job(

--- a/app/modules/spfy.py
+++ b/app/modules/spfy.py
@@ -332,10 +332,10 @@ def _phylotyper_pipeline(subtype, query_file, pipeline=None, backlog=False):
         None,
         subtype,
         tsvfile,
-        id_file=query_file + '_id.txt',
-        job_id=pipeline.jobs['job_id'].rq_job,
-        job_turtle=pipeline.jobs['job_turtle'].rq_job,
-        job_ectyper_datastruct_vf=pipeline.jobs['job_ectyper_datastruct_vf'].rq_job,
+        query_file + '_id.txt',
+        pipeline.jobs['job_id'].rq_job,
+        pipeline.jobs['job_turtle'].rq_job,
+        pipeline.jobs['job_ectyper_datastruct_vf'].rq_job,
         depends_on=job_ectyper_datastruct_vf)
     pipeline.jobs.update({
         'job'+jobname: Job(

--- a/app/modules/spfy.py
+++ b/app/modules/spfy.py
@@ -67,6 +67,8 @@ def _ectyper_pipeline_vf(query_file, single_dict, display_vf=True, pipeline=None
     d = {}
     # Alias.
     job_id = pipeline.jobs['job_id'].rq_job
+    job_turtle = pipeline.jobs['job_turtle'].rq_job
+
     if not backlog:
         singles = singles_q
         multiples = multiples_q
@@ -84,7 +86,7 @@ def _ectyper_pipeline_vf(query_file, single_dict, display_vf=True, pipeline=None
     job_ectyper_vf = singles.enqueue(
         call_ectyper_vf,
         single_dict_vf,
-        depends_on=job_id)
+        depends_on=job_turtle)
     # TODO: this is double, switch everything to pipeline once tested
     d['job_ectyper_vf'] = job_ectyper_vf
     pipeline.jobs.update({
@@ -331,7 +333,9 @@ def _phylotyper_pipeline(subtype, query_file, pipeline=None, backlog=False):
         subtype,
         tsvfile,
         id_file=query_file + '_id.txt',
-        query_file=query_file,
+        job_id=pipeline.jobs['job_id'].rq_job,
+        job_turtle=pipeline.jobs['job_turtle'].rq_job,
+        job_ectyper_datastruct_vf=pipeline.jobs['job_ectyper_datastruct_vf'].rq_job,
         depends_on=job_ectyper_datastruct_vf)
     pipeline.jobs.update({
         'job'+jobname: Job(

--- a/app/modules/spfy.py
+++ b/app/modules/spfy.py
@@ -333,9 +333,9 @@ def _phylotyper_pipeline(subtype, query_file, pipeline=None, backlog=False):
         subtype,
         tsvfile,
         query_file + '_id.txt',
-        pipeline.jobs['job_id'].rq_job,
-        pipeline.jobs['job_turtle'].rq_job,
-        pipeline.jobs['job_ectyper_datastruct_vf'].rq_job,
+        pipeline.jobs['job_id'].rq_job.get_id(),
+        pipeline.jobs['job_turtle'].rq_job.get_id(),
+        pipeline.jobs['job_ectyper_datastruct_vf'].rq_job.get_id(),
         depends_on=job_ectyper_datastruct_vf)
     pipeline.jobs.update({
         'job'+jobname: Job(

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -14,8 +14,8 @@ def fetch_job(job_id, redis_connection=None):
     Iterates through all queues looking for the job.
     '''
     if not redis_connection:
-        redis_connection = redis.from_url(config['REDIS_URL'])
-    queues = config['QUEUES_SPFY']
+        redis_connection = redis.from_url(config.REDIS_URL)
+    queues = config.QUEUES_SPFY
     for queue in queues:
         q = Queue(queue, connection=redis_connection)
         job = q.fetch_job(job_id)

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -1,4 +1,5 @@
 import redis
+import config
 from flask import current_app
 from rq import Queue
 
@@ -13,8 +14,8 @@ def fetch_job(job_id, redis_connection=None):
     Iterates through all queues looking for the job.
     '''
     if not redis_connection:
-        redis_connection = redis.from_url(current_app.config['REDIS_URL'])
-    queues = current_app.config['QUEUES_SPFY']
+        redis_connection = redis.from_url(config['REDIS_URL'])
+    queues = config['QUEUES_SPFY']
     for queue in queues:
         q = Queue(queue, connection=redis_connection)
         job = q.fetch_job(job_id)

--- a/app/scripts/savvy.py
+++ b/app/scripts/savvy.py
@@ -16,7 +16,7 @@ import tempfile
 import shutil
 import json
 from modules.qc.qc import qc
-from middleware.blazegraph.reserve_id import write_reserve_id
+from middleware.blazegraph.reserve_id import reserve_id
 from modules.ectyper.call_ectyper import call_ectyper_vf, call_ectyper_serotype
 from modules.amr.amr import amr
 from modules.amr.amr_to_dict import amr_to_dict

--- a/app/supervisord-rq-phylotyper.conf
+++ b/app/supervisord-rq-phylotyper.conf
@@ -28,7 +28,7 @@ autostart=true
 autorestart=true
 
 ; redirect stdout and stderr for docker logs
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/stderr
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0

--- a/app/supervisord-rq-phylotyper.conf
+++ b/app/supervisord-rq-phylotyper.conf
@@ -1,6 +1,5 @@
 [supervisord]
 nodaemon=true
-loglevel=debug
 
 [program:rqworkermultiples]
 ; Point the command to the specific rq command you want to run.
@@ -28,7 +27,7 @@ autostart=true
 autorestart=true
 
 ; redirect stdout and stderr for docker logs
-stdout_logfile=/dev/stderr
+stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0

--- a/app/supervisord-rq-phylotyper.conf
+++ b/app/supervisord-rq-phylotyper.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+loglevel=debug
 
 [program:rqworkermultiples]
 ; Point the command to the specific rq command you want to run.

--- a/app/tests/test_modules.py
+++ b/app/tests/test_modules.py
@@ -8,7 +8,7 @@ import cPickle as pickle
 import pandas as pd
 
 from modules.qc.qc import qc, check_header_parsing, check_ecoli
-from middleware.blazegraph.reserve_id import write_reserve_id
+from middleware.blazegraph.reserve_id import reserve_id
 from modules.ectyper.call_ectyper import call_ectyper_vf, call_ectyper_serotype
 from modules.amr.amr import amr
 from modules.amr.amr_to_dict import amr_to_dict

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -289,7 +289,7 @@ Directly Adding a New Module
 
 .. code-block:: python
 
-  from middleware.blazegraph.reserve_id import write_reserve_id
+  from middleware.blazegraph.reserve_id import reserve_id
 
 The top-most directory is used to build Docker Images and copies the contents of ``/app`` to run inside the containers. This is done as the apps (Flask, Reactapp) themselves don't need copies of the Dockerfiles, other apps, etc.
 


### PR DESCRIPTION
No longer queries Blazegraph for sequence results from ECTyper. Instead, retrieves and queries the graph object created by ectyper.